### PR TITLE
Fix lazy physics preset imports

### DIFF
--- a/source/isaaclab_tasks/config/extension.toml
+++ b/source/isaaclab_tasks/config/extension.toml
@@ -1,7 +1,7 @@
 [package]
 
 # Note: Semantic Versioning is used: https://semver.org/
-version = "1.5.25"
+version = "1.5.26"
 
 # Description
 title = "Isaac Lab Environments"

--- a/source/isaaclab_tasks/docs/CHANGELOG.rst
+++ b/source/isaaclab_tasks/docs/CHANGELOG.rst
@@ -1,6 +1,16 @@
 Changelog
 ---------
 
+1.5.26 (2026-04-28)
+~~~~~~~~~~~~~~~~~~~
+
+Fixed
+^^^^^
+
+* Fixed lazy preset loading so direct task physics presets can avoid importing
+  optional backend packages unless their preset is selected.
+
+
 1.5.25 (2026-04-23)
 ~~~~~~~~~~~~~~~~~~~
 

--- a/source/isaaclab_tasks/isaaclab_tasks/direct/ant/ant_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/direct/ant/ant_env_cfg.py
@@ -6,7 +6,6 @@
 from __future__ import annotations
 
 from isaaclab_newton.physics import MJWarpSolverCfg, NewtonCfg
-from isaaclab_ovphysx.physics import OvPhysxCfg
 from isaaclab_physx.physics import PhysxCfg
 
 import isaaclab.sim as sim_utils
@@ -17,7 +16,7 @@ from isaaclab.sim import SimulationCfg
 from isaaclab.terrains import TerrainImporterCfg
 from isaaclab.utils import configclass
 
-from isaaclab_tasks.utils import PresetCfg
+from isaaclab_tasks.utils import PresetCfg, lazy_preset
 
 from isaaclab_assets.robots.ant import ANT_CFG
 
@@ -37,7 +36,10 @@ class AntPhysicsCfg(PresetCfg):
         num_substeps=1,
         debug_mode=False,
     )
-    ovphysx: OvPhysxCfg = OvPhysxCfg()
+    ovphysx = lazy_preset(
+        "isaaclab_ovphysx.physics:OvPhysxCfg",
+        error_hint="Install the OV-PhysX backend before selecting the 'ovphysx' preset.",
+    )
 
 
 @configclass

--- a/source/isaaclab_tasks/isaaclab_tasks/direct/cartpole/cartpole_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/direct/cartpole/cartpole_env_cfg.py
@@ -6,7 +6,6 @@
 from __future__ import annotations
 
 from isaaclab_newton.physics import MJWarpSolverCfg, NewtonCfg
-from isaaclab_ovphysx.physics import OvPhysxCfg
 from isaaclab_physx.physics import PhysxCfg
 
 from isaaclab.assets import ArticulationCfg
@@ -15,7 +14,7 @@ from isaaclab.scene import InteractiveSceneCfg
 from isaaclab.sim import SimulationCfg
 from isaaclab.utils import configclass
 
-from isaaclab_tasks.utils import PresetCfg
+from isaaclab_tasks.utils import PresetCfg, lazy_preset
 
 from isaaclab_assets.robots.cartpole import CARTPOLE_CFG
 
@@ -36,7 +35,10 @@ class CartpolePhysicsCfg(PresetCfg):
         debug_mode=False,
         use_cuda_graph=True,
     )
-    ovphysx: OvPhysxCfg = OvPhysxCfg()
+    ovphysx = lazy_preset(
+        "isaaclab_ovphysx.physics:OvPhysxCfg",
+        error_hint="Install the OV-PhysX backend before selecting the 'ovphysx' preset.",
+    )
 
 
 @configclass

--- a/source/isaaclab_tasks/isaaclab_tasks/direct/humanoid/humanoid_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/direct/humanoid/humanoid_env_cfg.py
@@ -6,7 +6,6 @@
 from __future__ import annotations
 
 from isaaclab_newton.physics import MJWarpSolverCfg, NewtonCfg
-from isaaclab_ovphysx.physics import OvPhysxCfg
 from isaaclab_physx.physics import PhysxCfg
 
 import isaaclab.sim as sim_utils
@@ -17,7 +16,7 @@ from isaaclab.sim import SimulationCfg
 from isaaclab.terrains import TerrainImporterCfg
 from isaaclab.utils import configclass
 
-from isaaclab_tasks.utils import PresetCfg
+from isaaclab_tasks.utils import PresetCfg, lazy_preset
 
 from isaaclab_assets import HUMANOID_CFG
 
@@ -38,7 +37,10 @@ class HumanoidPhysicsCfg(PresetCfg):
         num_substeps=2,
         debug_mode=False,
     )
-    ovphysx: OvPhysxCfg = OvPhysxCfg()
+    ovphysx = lazy_preset(
+        "isaaclab_ovphysx.physics:OvPhysxCfg",
+        error_hint="Install the OV-PhysX backend before selecting the 'ovphysx' preset.",
+    )
 
 
 @configclass

--- a/source/isaaclab_tasks/isaaclab_tasks/direct/locomotion/locomotion_env.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/direct/locomotion/locomotion_env.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 import torch
 import warp as wp
 from isaaclab_newton.physics import NewtonCfg
-from isaaclab_ovphysx.physics import OvPhysxCfg
 from isaaclab_physx.physics import PhysxCfg
 
 import isaaclab.sim as sim_utils
@@ -80,7 +79,8 @@ class LocomotionEnv(DirectRLEnv):
         self.action_scale = self.cfg.action_scale
         # Resolve the joint gears based on the physics type, since they do not have the same joint ordering.
         if isinstance(self.cfg.joint_gears, dict):
-            if isinstance(self.cfg.sim.physics, (PhysxCfg, OvPhysxCfg)):
+            physics_type = type(self.cfg.sim.physics).__name__
+            if isinstance(self.cfg.sim.physics, PhysxCfg) or physics_type == "OvPhysxCfg":
                 joint_gears = self.cfg.joint_gears["physx"]
             elif isinstance(self.cfg.sim.physics, NewtonCfg):
                 joint_gears = self.cfg.joint_gears["newton"]

--- a/source/isaaclab_tasks/isaaclab_tasks/utils/__init__.pyi
+++ b/source/isaaclab_tasks/isaaclab_tasks/utils/__init__.pyi
@@ -9,6 +9,7 @@ __all__ = [
     "load_cfg_from_registry",
     "parse_env_cfg",
     "PresetCfg",
+    "lazy_preset",
     "preset",
     "resolve_task_config",
     "hydra_task_config",
@@ -18,7 +19,7 @@ __all__ = [
     "compute_kit_requirements",
 ]
 
-from .hydra import PresetCfg, preset, hydra_task_config, resolve_task_config, resolve_presets
+from .hydra import PresetCfg, lazy_preset, preset, hydra_task_config, resolve_task_config, resolve_presets
 from .importer import import_packages
 from .parse_cfg import get_checkpoint_path, load_cfg_from_registry, parse_env_cfg
 from .sim_launcher import add_launcher_args, launch_simulation, compute_kit_requirements

--- a/source/isaaclab_tasks/isaaclab_tasks/utils/hydra.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/utils/hydra.py
@@ -25,6 +25,7 @@ Example usage::
 """
 
 import functools
+import importlib
 import sys
 from collections.abc import Callable, Mapping
 
@@ -56,6 +57,77 @@ class PresetCfg:
     """
 
     pass
+
+
+class _LazyPreset:
+    """Lazy preset alternative backed by an import path."""
+
+    __slots__ = ("error_hint", "import_path", "kwargs")
+
+    def __init__(self, import_path: str, error_hint: str | None = None, kwargs: dict[str, object] | None = None):
+        self.import_path = import_path
+        self.error_hint = error_hint
+        self.kwargs = kwargs or {}
+
+    def __eq__(self, other: object) -> bool:
+        return (
+            isinstance(other, _LazyPreset)
+            and self.import_path == other.import_path
+            and self.error_hint == other.error_hint
+            and self.kwargs == other.kwargs
+        )
+
+    def load(self, preset_name: str) -> object:
+        module_name, _, attr_name = self.import_path.partition(":")
+        try:
+            module = importlib.import_module(module_name)
+            cfg_cls = getattr(module, attr_name)
+        except ModuleNotFoundError as exc:
+            raise ModuleNotFoundError(self._format_error(preset_name, exc)) from exc
+        except (AttributeError, ImportError) as exc:
+            raise ImportError(self._format_error(preset_name, exc)) from exc
+        return cfg_cls(**self.kwargs)
+
+    def _format_error(self, preset_name: str, exc: Exception) -> str:
+        message = f"Preset '{preset_name}' requires config '{self.import_path}', but it could not be imported."
+        if self.error_hint:
+            message += f" {self.error_hint}"
+        message += f" Original error: {exc}"
+        return message
+
+
+def lazy_preset(
+    import_path: str,
+    *,
+    error_hint: str | None = None,
+    **kwargs: object,
+) -> _LazyPreset:
+    """Create a preset alternative that imports its config only when selected.
+
+    The target class is imported and instantiated only when the preset is selected.
+    This lets task configs advertise presets without importing their backend
+    packages during normal config loading.
+
+    Args:
+        import_path: Import path in ``"module:ClassName"`` form.
+        error_hint: Optional guidance appended to import errors.
+        **kwargs: Keyword arguments forwarded to the imported config class.
+
+    Returns:
+        A lazy preset alternative that can be used as a :class:`PresetCfg` field.
+
+    Raises:
+        ValueError: If :attr:`import_path` is not in ``"module:ClassName"`` form.
+    """
+    module_name, sep, attr_name = import_path.partition(":")
+    if not sep or not module_name or not attr_name:
+        raise ValueError(f"Lazy preset import path must use 'module:ClassName' form, got: {import_path!r}.")
+    return _LazyPreset(import_path, error_hint, kwargs)
+
+
+def _materialize_lazy_preset(value, preset_name: str) -> object:
+    """Instantiate a lazy preset if needed."""
+    return value.load(preset_name) if isinstance(value, _LazyPreset) else value
 
 
 def preset(**options) -> PresetCfg:
@@ -179,9 +251,9 @@ def _pick_alternative(preset_obj: PresetCfg, selected: set[str], path: str = "")
     fields = _preset_fields(preset_obj)
     for name in selected:
         if name in fields:
-            return fields[name]
+            return _materialize_lazy_preset(fields[name], name)
     if "default" in fields:
-        return fields["default"]
+        return _materialize_lazy_preset(fields["default"], "default")
     raise ValueError(
         f"PresetCfg {type(preset_obj).__name__} at '{path}' has no 'default' field "
         f"and none of the selected presets {selected} match its fields {set(fields.keys())}."
@@ -522,7 +594,7 @@ def apply_overrides(
     for full_path in sorted(resolved, key=lambda fp: fp.count(".")):
         sec, path, name = resolved[full_path]
         if cfgs[sec] is not None and _path_reachable(sec, path):
-            node = presets[sec][path][name]
+            node = _materialize_lazy_preset(presets[sec][path][name], name)
             node_dict = (
                 node.to_dict() if hasattr(node, "to_dict") else dict(node) if isinstance(node, Mapping) else node
             )

--- a/source/isaaclab_tasks/test/test_hydra.py
+++ b/source/isaaclab_tasks/test/test_hydra.py
@@ -9,6 +9,9 @@ These tests verify the REPLACE-only preset system without depending on
 external environment configurations.
 """
 
+import sys
+import types
+
 import pytest
 
 from isaaclab.utils import configclass
@@ -17,6 +20,7 @@ from isaaclab_tasks.utils.hydra import (
     PresetCfg,
     apply_overrides,
     collect_presets,
+    lazy_preset,
     parse_overrides,
     preset,
     resolve_presets,
@@ -570,6 +574,21 @@ class EnvWithOptionalFeatureCfg:
     optional_feature: OptionalFeaturePresetCfg = OptionalFeaturePresetCfg()
 
 
+@configclass
+class LazyBackendPresetCfg(PresetCfg):
+    default: PhysxCfg = PhysxCfg()
+    optional_backend = lazy_preset(
+        "test_hydra_optional_backend:OptionalBackendCfg",
+        error_hint="Install the optional backend package.",
+    )
+
+
+@configclass
+class EnvWithLazyBackendCfg:
+    decimation: int = 4
+    backend: LazyBackendPresetCfg = LazyBackendPresetCfg()
+
+
 def test_presetcfg_none_default_auto_applies():
     """PresetCfg with default=None auto-applies None without crashing."""
     env_cfg, _ = _apply(EnvWithOptionalFeatureCfg())
@@ -586,6 +605,51 @@ def test_presetcfg_none_default_cli_selects_enabled():
     apply_overrides(env_cfg, agent_cfg, hydra_cfg, [], sel, [], presets)
     assert isinstance(env_cfg.optional_feature, OptionalFeatureCfg)
     assert env_cfg.optional_feature.buffer_size == 200
+
+
+def test_lazy_preset_default_does_not_import_missing_module():
+    """Lazy preset alternatives are discoverable but not imported when default resolves."""
+    presets = collect_presets(EnvWithLazyBackendCfg())
+    assert "optional_backend" in presets["backend"]
+    assert "test_hydra_optional_backend" not in sys.modules
+
+    env_cfg = resolve_presets(EnvWithLazyBackendCfg())
+
+    assert isinstance(env_cfg.backend, PhysxCfg)
+    assert "test_hydra_optional_backend" not in sys.modules
+
+
+def test_lazy_preset_selection_requires_installed_module():
+    """Selecting an unavailable lazy preset raises an actionable import error."""
+    with pytest.raises(ModuleNotFoundError, match="Install the optional backend package."):
+        resolve_presets(EnvWithLazyBackendCfg(), {"optional_backend"})
+
+
+def test_lazy_preset_path_selection_materializes_module(monkeypatch):
+    """Path selection imports and instantiates an available lazy preset."""
+
+    @configclass
+    class OptionalBackendCfg:
+        backend: str = "optional"
+        substeps: int = 8
+
+    module = types.ModuleType("test_hydra_optional_backend")
+    module.OptionalBackendCfg = OptionalBackendCfg
+    monkeypatch.setitem(sys.modules, "test_hydra_optional_backend", module)
+
+    env_cfg = EnvWithLazyBackendCfg()
+    agent_cfg = PresetCfgAgentCfg()
+    presets = {"env": collect_presets(env_cfg), "agent": collect_presets(agent_cfg)}
+    hydra_cfg = {
+        "env": resolve_presets(EnvWithLazyBackendCfg()).to_dict(),
+        "agent": agent_cfg.to_dict(),
+    }
+
+    apply_overrides(env_cfg, agent_cfg, hydra_cfg, [], [("env", "backend", "optional_backend")], [], presets)
+
+    assert isinstance(env_cfg.backend, OptionalBackendCfg)
+    assert env_cfg.backend.backend == "optional"
+    assert hydra_cfg["env"]["backend"]["substeps"] == 8
 
 
 def test_root_presetcfg_global_depth_resolves_nested():


### PR DESCRIPTION
## Summary
- Added generic lazy preset support for config alternatives backed by import paths.
- Moved direct task OV-PhysX physics presets to lazy imports so default config loading no longer imports isaaclab_ovphysx.
- Added regression coverage for lazy preset discovery, selection, and missing-package errors.

## Test Plan
- ./isaaclab.sh -f
- ./isaaclab.sh -p -m pre_commit run --files source/isaaclab_tasks/isaaclab_tasks/utils/hydra.py source/isaaclab_tasks/test/test_hydra.py source/isaaclab_tasks/isaaclab_tasks/direct/cartpole/cartpole_env_cfg.py source/isaaclab_tasks/isaaclab_tasks/direct/ant/ant_env_cfg.py source/isaaclab_tasks/isaaclab_tasks/direct/humanoid/humanoid_env_cfg.py source/isaaclab_tasks/isaaclab_tasks/direct/locomotion/locomotion_env.py source/isaaclab_tasks/docs/CHANGELOG.rst source/isaaclab_tasks/config/extension.toml source/isaaclab_tasks/isaaclab_tasks/utils/__init__.pyi
- PYTHONPYCACHEPREFIX=/tmp/isaaclab_pycache ./isaaclab.sh -p -m py_compile source/isaaclab_tasks/isaaclab_tasks/utils/hydra.py source/isaaclab_tasks/isaaclab_tasks/direct/cartpole/cartpole_env_cfg.py source/isaaclab_tasks/isaaclab_tasks/direct/ant/ant_env_cfg.py source/isaaclab_tasks/isaaclab_tasks/direct/humanoid/humanoid_env_cfg.py source/isaaclab_tasks/isaaclab_tasks/direct/locomotion/locomotion_env.py source/isaaclab_tasks/test/test_hydra.py

## Not Run
- PYTHONPYCACHEPREFIX=/tmp/isaaclab_pycache ./isaaclab.sh -p -m pytest source/isaaclab_tasks/test/test_hydra.py -q: blocked because the /usr/bin/python3.12 environment is missing torch.
- ./isaaclab.sh -d: blocked by PEP 668 externally-managed system Python while installing docs requirements.